### PR TITLE
Fix install typo/bug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ install: libbigfile.a libbigfile-mpi.a
 	install libbigfile.a $(PREFIX)/lib/libbigfile.a
 	install libbigfile-mpi.a $(PREFIX)/lib/libbigfile-mpi.a
 	install bigfile-mpi.h $(PREFIX)/include/bigfile-mpi.h
-	install bigfile.h $(PREFIX)/include/bigfile-mpi.h
+	install bigfile.h $(PREFIX)/include/bigfile.h
 
 bigfile.o: bigfile.c bigfile.h
 	$(CC) $(CFLAGS) -o $@ -c bigfile.c


### PR DESCRIPTION
It was installing bigfile.h over bigfile-mpi.h Don't want to do that.