### PR TITLE
Added CMake copmilation script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(bigfile)
+
+# Finding optional dependencies
+find_package(MPI)
+find_package(GSL)
+
+# Add library subdirectoy
+add_subdirectory(src)
+
+# Add executables subdirectory
+add_subdirectory(utils)

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,31 @@ To install the Python binding
 The C-API of bigfile can be embedded into a project, by dropping in 
 four files : bigfile.c bigfile-mpi.c, bigfile.h bigfile-mpi.h.
 
-However, if installation is preferred, use
+However, if installation is preferred, the library and executables can be compiled and installed
+using CMake:
+
+.. code:: bash
+    
+    mkdir build
+    cmake ..
+    make install
+    
+This will install the project in the default path (probalby /usr/local), to select an alternative
+installation destination, replace the cmake call by:
+
+.. code:: bash
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=<PREFIX> ..
+    
+where <PREFIX> is the desired destination.
+
+Compilation is also possible using the legacy build system:
 
 .. code:: bash
 
     make install
 
-Override CC MPICC, PREFIX as needed. Take a look at the Makefile is always recommended.
+However, you need to manually override CC MPICC, PREFIX as needed. Take a look at the Makefile is always recommended.
 
 
 Description

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,8 @@ install(TARGETS bigfile
         PUBLIC_HEADER DESTINATION include)
 
 if(${MPI_C_FOUND})
+    include_directories(${MPI_C_INCLUDE_PATH})
+
     add_library(bigfile-mpi bigfile-mpi.c)
     set_target_properties(bigfile-mpi PROPERTIES PUBLIC_HEADER bigfile-mpi.h)
     

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
+# Compile library 
+add_library(bigfile bigfile.c)
+set_target_properties(bigfile PROPERTIES PUBLIC_HEADER bigfile.h)
+
+install(TARGETS bigfile
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include)
+
+if(${MPI_C_FOUND})
+    add_library(bigfile-mpi bigfile-mpi.c)
+    set_target_properties(bigfile-mpi PROPERTIES PUBLIC_HEADER bigfile-mpi.h)
+    
+    install(TARGETS bigfile-mpi
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include)
+endif()

--- a/src/bigfile.h
+++ b/src/bigfile.h
@@ -1,6 +1,7 @@
 #ifndef _BIGFILE_H_
 #define _BIGFILE_H_
 #include <stddef.h>
+#include <stdio.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,71 @@
+# Compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")
+
+# Include library headers
+include_directories(${CMAKE_SOURCE_DIR}/src)
+
+# bigfile-get-attr
+add_executable(bigfile-get-attr bigfile-get-attr.c)
+target_link_libraries(bigfile-get-attr bigfile)
+
+# bigfile-set-attr
+add_executable(bigfile-set-attr bigfile-set-attr.c)
+target_link_libraries(bigfile-set-attr bigfile)
+
+# bigfile-copy
+add_executable(bigfile-copy bigfile-copy.c)
+target_link_libraries(bigfile-copy bigfile)
+
+# bigfile-cat
+add_executable(bigfile-cat bigfile-cat.c)
+target_link_libraries(bigfile-cat bigfile)
+
+# bigfile-create
+add_executable(bigfile-create bigfile-create.c)
+target_link_libraries(bigfile-create bigfile)
+
+# bigfile-ls
+add_executable(bigfile-ls bigfile-ls.c)
+target_link_libraries(bigfile-ls bigfile)
+
+# bigfile-checksum
+#add_executable(bigfile-checksum bigfile-checksum.c)
+#target_link_libraries(bigfile-checksum bigfile)
+
+# bigfile-join
+# add_executable(bigfile-join bigfile-join.c)
+# target_link_libraries(bigfile-join bigfile)
+
+# Install tagets
+install(TARGETS bigfile-get-attr bigfile-set-attr bigfile-copy # bigfile-checksum
+                bigfile-cat bigfile-create bigfile-ls # bigfile-join
+        RUNTIME DESTINATION bin)
+
+# MPI specific executables
+if(${MPI_C_FOUND})
+    # bigfile-copy-mpi
+    add_executable(bigfile-copy-mpi bigfile-copy-mpi.c)
+    target_link_libraries(bigfile-copy-mpi bigfile bigfile-mpi ${MPI_C_LIBRARIES})
+    
+    # bigfile-iosim
+    add_executable(bigfile-iosim bigfile-iosim.c)
+    target_link_libraries(bigfile-iosim bigfile bigfile-mpi ${MPI_C_LIBRARIES})
+    
+    install(TARGETS bigfile-copy-mpi bigfile-iosim
+            RUNTIME DESTINATION bin)
+    
+    if(${GSL_FOUND})
+        include_directories(${GSL_INCLUDE_DIRS})
+
+        # bigfile-sample-mpi
+        add_executable(bigfile-sample-mpi bigfile-sample-mpi.c)
+        target_link_libraries(bigfile-sample-mpi bigfile bigfile-mpi ${GSL_LIBRARIES} ${MPI_C_LIBRARIES})
+        
+        install(TARGET bigfile-sample-mpi
+                RUNTIME DESTINATION bin)
+    endif()
+endif()
+
+# Install bash scripts
+install(PROGRAMS bigfile-check bigfile-rename bigfile-repartition bigfile-rm
+        DESTINATION bin)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -61,7 +61,7 @@ if(${MPI_C_FOUND})
         add_executable(bigfile-sample-mpi bigfile-sample-mpi.c)
         target_link_libraries(bigfile-sample-mpi bigfile bigfile-mpi ${GSL_LIBRARIES} ${MPI_C_LIBRARIES})
         
-        install(TARGET bigfile-sample-mpi
+        install(TARGETS bigfile-sample-mpi
                 RUNTIME DESTINATION bin)
     endif()
 endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -43,10 +43,12 @@ install(TARGETS bigfile-get-attr bigfile-set-attr bigfile-copy # bigfile-checksu
 
 # MPI specific executables
 if(${MPI_C_FOUND})
+    include_directories(${MPI_C_INCLUDE_PATH})
+    
     # bigfile-copy-mpi
     add_executable(bigfile-copy-mpi bigfile-copy-mpi.c)
     target_link_libraries(bigfile-copy-mpi bigfile bigfile-mpi ${MPI_C_LIBRARIES})
-    
+
     # bigfile-iosim
     add_executable(bigfile-iosim bigfile-iosim.c)
     target_link_libraries(bigfile-iosim bigfile bigfile-mpi ${MPI_C_LIBRARIES})


### PR DESCRIPTION
This pull request adds a cmake compilation framework for automatic compilation, linking and installation of the bigfile C library. The original makefile is not modified, this only adds an alternative compilation solution.

CMake makes it easy to automatically find the GSL and MPI dependencies without manually modifying the makefile. Plus, the C library can then easily be compiled and link by other cmake projects using the ExternalProject_Add command.