### PR TITLE
Fix crashes in bigfile

### DIFF
--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -29,7 +29,7 @@ int big_file_mpi_open(BigFile * bf, const char * basename, MPI_Comm comm) {
     MPI_Comm_rank(comm, &rank);
     int rt = 0;
     if (rank == 0) {
-        big_file_open(bf, basename);
+        rt = big_file_open(bf, basename);
     } else {
         /* FIXME : */
         bf->basename = strdup(basename);

--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -61,6 +61,7 @@ int big_file_mpi_create(BigFile * bf, const char * basename, MPI_Comm comm) {
 }
 int big_file_mpi_open_block(BigFile * bf, BigBlock * block, const char * blockname, MPI_Comm comm) {
     if(comm == MPI_COMM_NULL) return 0;
+    if(!bf || !bf->basename || !blockname) return 1;
     char * basename = alloca(strlen(bf->basename) + strlen(blockname) + 128);
     sprintf(basename, "%s/%s/", bf->basename, blockname);
     return big_block_mpi_open(block, basename, comm);

--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -199,11 +199,10 @@ static void big_file_mpi_broadcast_error(int root, MPI_Comm comm) {
     }
 }
 static int big_block_mpi_broadcast(BigBlock * bb, int root, MPI_Comm comm) {
-    ptrdiff_t i;
     int rank;
     MPI_Comm_rank(comm, &rank);
     int lname = 0;
-    void * attrpack;
+    void * attrpack=NULL;
     size_t attrpacksize = 0;
     if(rank == root) {
         lname = strlen(bb->basename);
@@ -314,7 +313,7 @@ _throttle_plan_create(ThrottlePlan * plan, MPI_Comm comm, int concurrency, BigBl
     return 0;
 }
 
-static int _throttle_plan_destroy(ThrottlePlan * plan)
+static void _throttle_plan_destroy(ThrottlePlan * plan)
 {
     MPI_Comm_free(&plan->group);
     MPI_Type_free(&plan->mpidtype);

--- a/src/bigfile.c
+++ b/src/bigfile.c
@@ -197,7 +197,6 @@ static int (filter)(const struct dirent * ent) {
 static struct
 bblist * listbigfile_r(const char * basename, char * blockname, struct bblist * bblist) {
     struct dirent **namelist;
-    struct stat st;
     int n;
     int i;
 
@@ -212,7 +211,6 @@ bblist * listbigfile_r(const char * basename, char * blockname, struct bblist * 
     for(i = 0; i < n ; i ++) {
         char * blockname1 = _path_join(blockname, namelist[i]->d_name);
         char * fullpath1 = _path_join(basename, blockname1);
-        BigBlock bb = {0};
         if(_big_file_path_is_block(fullpath1)) {
             struct bblist * n = malloc(sizeof(struct bblist) + strlen(blockname1) + 1);
             n->next = bblist;
@@ -436,7 +434,6 @@ _big_block_create_internal(BigBlock * bb, const char * basename, const char * dt
         return 0;
 ex_flush:
         attrset_free(bb->attrset);
-ex_fileio:
         free(bb->foffset);
 ex_foffset:
         free(bb->fchecksum);


### PR DESCRIPTION
Fix a couple of small crash errors in bigfile. One of them means an error in big_file_mpi_open does not propagate and thus MP-Gadget crashes if reading a non-existent snapshot.