### PR TITLE
Improved Aggregation during IO.

### DIFF
--- a/src/bigfile-mpi.h
+++ b/src/bigfile-mpi.h
@@ -81,6 +81,8 @@ int big_block_mpi_grow_simple(BigBlock * block, int Nfile_grow, size_t fsize_gro
 void big_file_mpi_set_aggregated_threshold(size_t bytes);
 size_t big_file_mpi_get_aggregated_threshold();
 
+void big_file_mpi_set_verbose(int verbose);
+
 /** Write data stored in a BigArray to a BigBlock.
  * You cannot write beyond the end of the size of the block.
  * The value may be a (small) array.

--- a/utils/bigfile-iosim.c
+++ b/utils/bigfile-iosim.c
@@ -188,7 +188,9 @@ iosim(char * filename)
             info("Initialized FakeData\n");
             info("Writing BigBlock\n");
             t0 = MPI_Wtime();
-            big_block_mpi_write(&bb, &ptr, &array, Nwriter, MPI_COMM_WORLD);
+            if(0 != big_block_mpi_write(&bb, &ptr, &array, Nwriter, MPI_COMM_WORLD)) {
+                info("Error occured: %s\n", big_file_get_error_message());
+            }
             t1 = MPI_Wtime();
             trank.write += t1 - t0;
             info("Written BigBlock\n");
@@ -198,7 +200,9 @@ iosim(char * filename)
             info("Reading BigBlock\n");
 
             t0 = MPI_Wtime();
-            big_block_mpi_read(&bb, &ptr, &array, Nwriter, MPI_COMM_WORLD);
+            if(0 != big_block_mpi_read(&bb, &ptr, &array, Nwriter, MPI_COMM_WORLD)) {
+                info("Error occured: %s\n", big_file_get_error_message());
+            }
             t1 = MPI_Wtime();
             trank.read += t1 - t0;
             info("Reading took %f seconds\n", trank.read);


### PR DESCRIPTION
This will automatically bundle data into segments of roughly
the AggregationThreshold in size, then group the segments
into writer groups, and throttle in the group.

should have helped in reducing the number of throttled IOs when
each rank has data that is smaller than the total.

Also should have improved the load balancing as segments are of the same size.