### PR TITLE
Fix typo

### DIFF
--- a/src/bigfile.c
+++ b/src/bigfile.c
@@ -1866,7 +1866,7 @@ _big_block_pack(BigBlock * block, size_t * bytes)
         memcpy(ptr, block->foffset, (Nfile + 1) * sizeof(block->foffset[0]));
     ptr += (Nfile + 1) * sizeof(block->foffset[0]);
     if(block->fchecksum)
-        memcpy(ptr, block->fchecksum, (Nfile + 1j) * sizeof(block->fchecksum[0]));
+        memcpy(ptr, block->fchecksum, (Nfile + 1) * sizeof(block->fchecksum[0]));
     ptr += (Nfile + 1) * sizeof(block->fchecksum[0]);
     memcpy(ptr, attrset, attrsize);
     ptr += attrsize;


### PR DESCRIPTION
Found because icc will refuse to compile it.

Incidentally, when you updated MP-Gadget's bigfile build, you updated to a version from 2017. Did you mean to do that?