### PR TITLE
Avoid use of MPI_2INT

### DIFF
--- a/src/bigfile-internal.h
+++ b/src/bigfile-internal.h
@@ -32,8 +32,9 @@ int _big_block_create(BigBlock * bb, const char * basename, const char * dtype, 
 static inline char *
 _strdup(const char * s)
 {
-    size_t l = strlen(s);
+    size_t l = strnlen(s,8192);
     char * r = malloc(l + 1);
-    strcpy(r, s);
+    strncpy(r, s, l);
+    r[l] = '\0';
     return r;
 }

--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -278,20 +278,19 @@ big_file_mpi_broadcast_anyerror(int rt, MPI_Comm comm)
 {
     int rank;
     MPI_Comm_rank(comm, &rank);
+    int root, loc = 0;
+    /* Add 1 so we do not swallow errors on rank 0*/
+    if(rt != 0)
+        loc = rank+1;
 
-    struct {
-        int value;
-        int loc;
-    } ii = {rt != 0, rank};
+    MPI_Allreduce(&loc, &root, 1, MPI_INT, MPI_MAX, comm);
 
-    MPI_Allreduce(MPI_IN_PLACE, &ii, 1, MPI_2INT, MPI_MAXLOC, comm);
-
-    if (ii.value == 0) {
+    if (root == 0) {
         /* no errors */
         return 0;
     }
-    int root = ii.loc;
 
+    root -= 1;
     char * error = big_file_get_error_message();
 
     int errorlen;

--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -351,7 +351,7 @@ _assign_colors(size_t glocalsize, size_t * sizes, int * ncolor, MPI_Comm comm)
     MPI_Comm_size(comm, &NTask);
 
     int i;
-    int mycolor;
+    int mycolor = -1;
     size_t current_size = 0;
     int current_color = 0;
     int lastcolor = 0;

--- a/src/bigfile.c
+++ b/src/bigfile.c
@@ -187,7 +187,6 @@ __raise__(const char * msg, const char * file, const int line, ...)
 int
 big_file_open(BigFile * bf, const char * basename)
 {
-    memset(bf, 0, sizeof(bf[0]));
     struct stat st;
     RAISEIF(0 != stat(basename, &st),
             ex_stat,
@@ -200,7 +199,6 @@ ex_stat:
 }
 
 int big_file_create(BigFile * bf, const char * basename) {
-    memset(bf, 0, sizeof(bf[0]));
     bf->basename = _strdup(basename);
     RAISEIF(0 != _big_file_mksubdir_r(NULL, basename),
         ex_subdir,
@@ -1005,12 +1003,13 @@ _dtype_normalize(char * dst, const char * src)
         case '>':
         case '|':
         case '=':
-            strcpy(dst, src);
+            strncpy(dst, src, 8);
         break;
         default:
             dst[0] = '=';
-            strcpy(dst + 1, src);
+            strncpy(dst + 1, src, 7);
     }
+    dst[7]='\0';
     if(dst[0] == '=') {
         dst[0] = MACHINE_ENDIANNESS;
     }


### PR DESCRIPTION
The error broadcasting algorithm with MPI_IN_PLACE and MPI_2INT
continues to give trouble on Frontera with intel MPI 18. Just avoid
it. It is an obscure enough part of the MPI standard that it is likely
often buggy.

It seems easier to just not do this than to keep arguing with Frontera and intel!